### PR TITLE
Add license file and fix build on Ubuntu 18.04

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,35 @@
+This license can be viewed online:
+	http://azul3d.org/doc/license.html
+
+The Azul3D Authors are listed online:
+	http://azul3d.org/doc/authors.html
+
+Copyright (c) 2014 The Azul3D Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Lightpoke nor the names of its contributors may be used
+  to endorse or promote products derived from this software without specific
+  prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/mouse/mouse.go
+++ b/mouse/mouse.go
@@ -36,8 +36,8 @@ const (
 // Left, Right, Middle and Wheel are simply aliases. Their true names are mouse
 // button One, Two, and Three (for both Middle and Wheel, respectively).
 const (
-	Left  = One
-	Right = Two
-	Wheel = Three
+	Left   = One
+	Right  = Two
+	Wheel  = Three
 	Middle = Three
 )

--- a/native/al/doc.go
+++ b/native/al/doc.go
@@ -32,4 +32,3 @@
 // and it will be automatically placed there once again.
 //
 package al // import "azul3d.org/engine/native/al"
-

--- a/native/freetype/context.go
+++ b/native/freetype/context.go
@@ -8,7 +8,7 @@ package freetype
 #cgo windows,amd64 LDFLAGS: libfreetype_windows_amd64.a libpng_windows_amd64.a libz_windows_amd64.a libbz2_windows_amd64.a
 #cgo windows,amd64 CFLAGS: -I freetype-2.5.0.1/include/
 
-#cgo linux LDFLAGS: -l:libfreetype.a -l:libpng.a -l:libz.a -l:libbz2.a -l:libm.a
+#cgo linux LDFLAGS: -l:libfreetype.a -l:libpng.a -l:libz.a -l:libbz2.a -lm
 #cgo linux CFLAGS: -I/usr/include/freetype2
 
 // TODO(slimsag): add the other OS X freetype versions

--- a/native/freetype/context.go
+++ b/native/freetype/context.go
@@ -8,7 +8,7 @@ package freetype
 #cgo windows,amd64 LDFLAGS: libfreetype_windows_amd64.a libpng_windows_amd64.a libz_windows_amd64.a libbz2_windows_amd64.a
 #cgo windows,amd64 CFLAGS: -I freetype-2.5.0.1/include/
 
-#cgo linux LDFLAGS: -l:libfreetype.a -l:libz.a -l:libpng.a -l:libbz2.a -l:libm.a
+#cgo linux LDFLAGS: -l:libfreetype.a -l:libpng.a -l:libz.a -l:libbz2.a -l:libm.a
 #cgo linux CFLAGS: -I/usr/include/freetype2
 
 // TODO(slimsag): add the other OS X freetype versions


### PR DESCRIPTION
Hi. One of my projects uses `azul3d.org/native/freetype.v1`, and a user notified me there's something wrong with the azul3d-legacy repository hosting:

```
$ git clone https://azul3d.org/native/freetype.v1
Cloning into 'freetype.v1'...
error: RPC failed; HTTP 301 curl 22 The requested URL returned error: 301
fatal: The remote end hung up unexpectedly
```

Apparently, fetching to existing clones works, but new clones don't.

Oh well, I figured I'd use this excuse to upgrade to the new import path -- but that didn't build! Included are two cleanup commits and then Linux build fixes. Let me know if there's anything that needs clarification beyond the commit messages.
